### PR TITLE
Fix once cleanup and tidy tests

### DIFF
--- a/Testing/on-event.test.js
+++ b/Testing/on-event.test.js
@@ -3,7 +3,6 @@ import { on, off } from '../src/on-event.js'
 
 describe('micro-on', () => {
   let el, child
-micro-on.test
   beforeEach(() => {
     el = document.createElement('div')
     child = document.createElement('button')

--- a/src/on-event.js
+++ b/src/on-event.js
@@ -10,12 +10,20 @@ function baseOn(el, type, selector, cb, options = {}) {
     selector = null
   }
 
-  const wrapped = selector
+  let wrapped = selector
     ? (e) => {
         const match = e.target.closest(selector)
         if (match && el.contains(match)) cb.call(match, e)
       }
     : cb
+
+  if (options.once) {
+    const orig = wrapped
+    wrapped = (e) => {
+      off(el, type, cb, selector)
+      orig(e)
+    }
+  }
 
   el.addEventListener(type, wrapped, options)
 


### PR DESCRIPTION
## Summary
- clean up old "micro-on" project name from the test suite
- ensure .once handlers remove themselves from the registry
