### PR TITLE
Clean up 'micro-on' references

### DIFF
--- a/Testing/on-event.test.js
+++ b/Testing/on-event.test.js
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { on, off } from '../src/on-event.js'
 
-describe('micro-on', () => {
+describe('on-events', () => {
   let el, child
   beforeEach(() => {
     el = document.createElement('div')
@@ -9,6 +9,10 @@ describe('micro-on', () => {
     child.textContent = 'Click Me'
     el.appendChild(child)
     document.body.appendChild(el)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(el)
   })
 
   it('binds a direct event', () => {

--- a/example-api.js
+++ b/example-api.js
@@ -1,4 +1,4 @@
-import { on, off } from 'micro-on'
+import { on, off } from 'on-events'
 
 // Delegate click inside #nav
 const stop = on(document, 'click', '#nav a', e => {

--- a/src/on-event.js
+++ b/src/on-event.js
@@ -1,4 +1,4 @@
-// micro-on.js
+// on-event.js
 
 // --- internal base ---
 const listeners = new WeakMap()
@@ -6,6 +6,13 @@ const listeners = new WeakMap()
 
 function baseOn(el, type, selector, cb, options = {}) {
   if (typeof selector === 'function') {
+    if (cb && typeof cb === 'object') {
+      options = cb
+    }
+    cb = selector
+    selector = null
+  } else if (cb && typeof cb === 'object') {
+    options = cb
     cb = selector
     selector = null
   }


### PR DESCRIPTION
## Summary
- update package comment header to the current project name
- fix option argument support in `baseOn`
- rename the old example file and update its import
- update test suite name and clean up DOM after tests

## Testing
- `npx vitest run` *(fails: command not found)*